### PR TITLE
feat(powershell): search across tenant

### DIFF
--- a/private_dot_config/powershell/Microsoft.PowerShell_profile.ps1
+++ b/private_dot_config/powershell/Microsoft.PowerShell_profile.ps1
@@ -45,7 +45,7 @@ Function Find-Resources {
         [Switch]$FullDisplay
     )
     $query = "where name contains '$Name' | where type contains '$Type' | where id contains '$Id' | order by name desc"
-    $result = Search-AzGraph -Query $query
+    $result = Search-AzGraph -Query $query -UseTenantScope
     if ($FullDisplay) {
         Write-Output $result
     }


### PR DESCRIPTION
Azure resource graph has by default switched to search only in current subscription. With this change it will search across all subscriptions in the tenant.